### PR TITLE
Scaffold Terraform envs, modules, and runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,139 +1,49 @@
 # blackroad-os-infra
 
-Infrastructure-as-code and runbooks for BlackRoad OS: DNS, Cloudflare, Railway environments, deployment patterns, and architectural guidelines.
+Infrastructure-as-code and operational runbooks for the BlackRoad OS ecosystem. This repo defines Terraform scaffolding, shared modules, and checklists so humans and agents can manage environments consistently—no direct cloud console edits.
 
-## Contents
+## How Things Connect
 
-- [**Lanes**](#lanes) — End-to-end feature patterns (UI → API → Core → DB)
-- [**Quick Start**](#quick-start) — Build all repos with execution prompts
-- [**Runbooks**](#runbooks) — Operational guides for deployments, incidents, and development
-- [**Environments**](#environments) — Railway environment configurations
-- [**DNS**](#dns) — Cloudflare DNS setup and management
-
----
-
-## Lanes
-
-**Lanes** are vertical slices of functionality that span the entire BlackRoad OS stack from UI to database.
-
-### Documentation
-
-- 📘 [**How to Build a Lane**](./runbooks/how-to-build-a-lane.md) — Step-by-step guide for implementing new features
-- 📋 [**Lane Template**](./docs/lanes/_lane-template.md) — Copy-paste template for new lanes
-- ✅ [**Agent Registry v1**](./docs/lanes/agent-registry-v1.md) — Canonical example (first working lane)
-
-### What is a Lane?
-
-A lane provides:
-- UI in Prism Console (forms, tables, views)
-- API proxy in blackroad-os-api (public surface)
-- Business logic in blackroad-os-core (CRUD operations)
-- Database persistence in PostgreSQL (Prisma models)
-
-**Example:** Agent Registry v1 allows admins to create and manage Agents through Prism Console, with full CRUD operations persisted in Postgres.
-
----
-
-## Quick Start
-
-### Build All Repos (Fastest Path to Production)
-
-Complete, copy-paste ready prompts to build out all features at once:
-
-#### 1. Core
-```bash
-cd ~/projects/blackroad-os-core
-claude
-# Paste: docs/execution-prompts/core-all-seasons.md
+```
+Code Repos (api, core, web, prism-console, agents)
+           ↓
+   Terraform Modules (dns, networking, app_service, monitoring, secrets)
+           ↓
+     Environments (dev → staging → prod)
+           ↓
+   Platforms (Railway, Cloudflare)
 ```
 
-**Adds:**
-- AgentRun model (trigger runs, history)
-- Task model (CRUD operations)
-- User model (JWT auth)
-- Validation utils + error standardization
-- In-memory metrics + request IDs
-- Jest tests + GitHub Actions CI
+## Key Folders
 
-#### 2. API
-```bash
-cd ~/projects/blackroad-os-api
-claude
-# Paste: docs/execution-prompts/api-all-seasons.md
-```
+- `envs/` — Environment definitions (`dev`, `staging`, `prod`) that compose shared modules
+- `modules/` — Reusable Terraform modules (`networking`, `dns`, `app_service`, `monitoring`, `secrets`)
+- `runbooks/` — Deployment, incident, and maintenance checklists for humans/agents
+- `docs/` — Environment/DNS/Railway/observability guides plus legacy lane docs
 
-**Adds:**
-- Agent runs proxy
-- Tasks proxy
-- Auth proxy
-- Request ID propagation
-- Metrics proxy
-- Proxy tests with nock + CI
+## Operating Rules
 
-#### 3. Console
-```bash
-cd ~/projects/blackroad-os-prism-console
-claude
-# Paste: docs/execution-prompts/console-all-seasons.md
-```
+- All infrastructure changes flow through this repo and pull requests.
+- Prefer environment variables for credentials (e.g., `CLOUDFLARE_API_TOKEN`) once secret storage is wired.
+- Keep dev/staging/prod configurations aligned; document intentional drift.
 
-**Adds:**
-- Agent runs UI (trigger + history)
-- Tasks UI (create, list, update, delete)
-- Login/register pages
-- Protected routes + auth context
-- Status dashboard with metrics
-- React Testing Library tests + CI
+## Getting Started
 
-### Resources
-- 📂 [**Execution Prompts**](./docs/execution-prompts/) — Complete prompts for all repos
-- 📊 [**Season Tracker**](./docs/season-tracker.md) — Track backend progress across repos
-- 📝 [**PR Templates**](./docs/pr-templates/) — Ready-to-use PR descriptions
-
----
-
-### Build All Websites (Consistent Patterns)
-
-Single prompt that works for ALL websites (Console, Web, Home, Brand, Docs):
+1. Pick an environment under `envs/<env>` and review its README.
+2. Configure required variables (tfvars or environment variables).
+3. Run Terraform:
 
 ```bash
-cd ~/projects/blackroad-os-<website-name>
-claude
-# Paste: docs/execution-prompts/websites-all-features.md
+terraform init
+terraform plan -var-file=<env>.tfvars
+terraform apply -var-file=<env>.tfvars
 ```
 
-**Adds to each website:**
-- Health & metadata endpoints (`/health`, `/api/info`, `/api/version`)
-- Standardized environment configuration
-- Consistent navigation with service links
-- Brand CSS variables integration
-- System status widgets
-- Complete documentation
+## Runbooks and Docs
 
-📊 [**Website Tracker**](./docs/website-tracker.md) — Track website progress
+- Deployment playbook: `runbooks/deployments/core_services.md`
+- Incident response: `runbooks/incidents/`
+- Maintenance: `runbooks/maintenance/`
+- Guides: `docs/env-overview.md`, `docs/cloudflare-dns-blueprint.md`, `docs/railway-guide.md`, `docs/observability-and-alerts.md`
 
----
-
-## Runbooks
-
-Operational guides for common tasks:
-
-- 🚀 [**How to Build a Lane**](./runbooks/how-to-build-a-lane.md) — Build end-to-end features
-- 📦 [**Deployments**](./runbooks/deployments.md) — Deployment procedures and Railway config
-- 🔥 [**Incidents**](./runbooks/incidents.md) — Incident response and debugging
-
----
-
-## Environments
-
-Railway environment configurations and service topology:
-
-- See [environments/](./environments/) for detailed setup
-
----
-
-## DNS
-
-Cloudflare DNS configuration and domain management:
-
-- See [dns/](./dns/) for DNS records and setup
+> TODO(agent/human): Fill in real provider credentials, Railway automation, and monitoring integrations as the platform matures.

--- a/dns/README.md
+++ b/dns/README.md
@@ -1,37 +1,9 @@
-# DNS Configuration
+# DNS Configuration (Legacy Placeholder)
 
-This directory contains DNS configuration and management for BlackRoad OS infrastructure.
+DNS infrastructure-as-code is now modeled in the Terraform [`modules/dns`](../modules/dns/) module and wired through environment definitions in `envs/<env>`. This directory is kept for historical reference.
 
-## Purpose
+## Where to Look
 
-Manage DNS records, zones, and configurations for all BlackRoad OS domains and services.
-
-## What Belongs Here
-
-- DNS zone configurations
-- Domain records (A, AAAA, CNAME, TXT, MX, etc.)
-- DNS provider configurations (e.g., Cloudflare)
-- DNS-related automation scripts
-- Documentation for DNS architecture and policies
-
-## Structure (Future)
-
-```
-dns/
-├── zones/           # DNS zone files
-├── records/         # Individual record configurations
-├── providers/       # Provider-specific configurations
-└── README.md        # This file
-```
-
-## Getting Started
-
-This directory is currently a placeholder. DNS infrastructure-as-code will be added in future iterations.
-
-## Best Practices
-
-- Always test DNS changes in a non-production environment first
-- Document the purpose of each DNS record
-- Use version control for all DNS configuration changes
-- Follow naming conventions for consistency
-- Keep TTL values appropriate for each record type
+- Cloudflare zone and records: `modules/dns`
+- Environment-specific records: `envs/<env>/variables.tf` or tfvars
+- Operational steps: `docs/cloudflare-dns-blueprint.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,68 +1,19 @@
-# BlackRoad OS Documentation
+# BlackRoad OS Infrastructure Docs
 
-Architectural documentation and patterns for BlackRoad OS.
+Infrastructure design notes, environment overviews, and operational guides to support the Terraform layout in this repo. Legacy application lane docs remain for reference.
 
-## Lanes
+## Core Guides
 
-**Lanes** are end-to-end vertical slices that span from UI to database. Each lane represents a coherent feature with clear separation of concerns across services.
+- [Environment Overview](./env-overview.md)
+- [Railway Guide](./railway-guide.md)
+- [Cloudflare DNS Blueprint](./cloudflare-dns-blueprint.md)
+- [Observability and Alerts](./observability-and-alerts.md)
 
-### Available Lanes
+## Runbooks
 
-- ✅ [**Agent Registry v1**](./lanes/agent-registry-v1.md) — First working lane (canonical example)
+Operational checklists live under [../runbooks](../runbooks/), organized by deployments, incidents, and maintenance.
 
-### Resources
+## Legacy Application Docs
 
-- 📋 [**Lane Template**](./lanes/_lane-template.md) — Copy-paste template for new lanes
-- 📘 [**How to Build a Lane**](../runbooks/how-to-build-a-lane.md) — Step-by-step implementation guide
-
----
-
-## Lane Architecture
-
-Every lane follows this pattern:
-
-```
-Prism Console UI → Console API Route → Public API (Proxy) → Core Logic → Database
-   (Next.js)          (/api/...)         (Express)          (Prisma)    (Postgres)
-```
-
-**Key Principles:**
-
-1. **Core owns data** — Prisma models and business logic live in `blackroad-os-core`
-2. **API proxies** — `blackroad-os-api` forwards requests without owning logic
-3. **Console provides UX** — `blackroad-os-prism-console` handles UI/UX only
-4. **Environment-based config** — Each service points upstream via env vars
-5. **Health checks everywhere** — Every service exposes `/health` for Railway
-
----
-
-## Quick Start
-
-To build a new lane:
-
-1. Read the [Agent Registry v1 example](./lanes/agent-registry-v1.md)
-2. Copy the [Lane Template](./lanes/_lane-template.md)
-3. Follow the [How to Build a Lane runbook](../runbooks/how-to-build-a-lane.md)
-
----
-
-## Service Responsibilities
-
-| Service | Owns | Technology | Port (local) |
-|---------|------|------------|--------------|
-| **blackroad-os-core** | Data schema, business logic, persistence | Express + TypeScript + Prisma + Postgres | 8081 |
-| **blackroad-os-api** | Public API surface, generic proxying | Express + TypeScript + Axios | 8080 |
-| **blackroad-os-prism-console** | Admin UI, user experience | Next.js 16 + React 19 | 3000 (dev) / 8080 (prod) |
-
----
-
-## Contributing
-
-When building new features:
-
-1. **Use the Lane pattern** for anything with UI + data persistence
-2. **Follow existing conventions** for ports, env vars, health checks
-3. **Document as you go** — update READMEs and create lane docs
-4. **Test end-to-end** — verify all three services work together locally
-
-See the [runbooks](../runbooks/) for operational guides.
+- Lanes: [Agent Registry v1](./lanes/agent-registry-v1.md), [Lane Template](./lanes/_lane-template.md)
+- Execution prompts and PR templates remain under `docs/execution-prompts` and `docs/pr-templates` for reference while infra automation matures.

--- a/docs/cloudflare-dns-blueprint.md
+++ b/docs/cloudflare-dns-blueprint.md
@@ -1,0 +1,25 @@
+# Cloudflare DNS Blueprint
+
+## Base Zone
+
+- Primary zone: `blackroad.systems`
+- Subdomains per environment follow the pattern `<service>.<env>.blackroad.systems` or `<env>-<service>.blackroad.systems` as needed.
+
+## Naming Conventions
+
+- `env-service.blackroad.systems` (e.g., `dev-api.blackroad.systems`, `stg-web.blackroad.systems`)
+- `service.env.blackroad.systems` when Cloudflare-specific rules make it cleaner (e.g., `api.dev.blackroad.systems`)
+
+## Managing DNS via Terraform
+
+1. Add or update records in the environment `records` variable (`envs/<env>/variables.tf` or tfvars)
+2. Run `terraform plan -var-file=<env>.tfvars` to review changes
+3. Run `terraform apply -var-file=<env>.tfvars`
+4. Verify in Cloudflare dashboard or with `dig`
+
+## Module Behavior
+
+- The [`dns` module](../modules/dns) creates/associates the Cloudflare zone and provisions records declared in `records`.
+- Outputs expose `zone_id` and per-record IDs to feed downstream automation.
+
+> TODO(agent): Add MX/TXT/SRV support and automatic TLS/HTTP routing policies as services mature.

--- a/docs/env-overview.md
+++ b/docs/env-overview.md
@@ -1,0 +1,17 @@
+# Environment Overview
+
+| Environment | Purpose | DNS Pattern | Notes |
+| ----------- | ---------------- | ------------------------- | ---------------------------------------- |
+| dev | Experimentation | `*.dev.blackroad.systems` | Ephemeral, unstable allowed. |
+| staging | Pre-prod testing | `*.stg.blackroad.systems` | Must mirror prod as closely as possible. |
+| prod | Live traffic | `*.blackroad.systems` | Strict change control. |
+
+## Usage
+
+- **dev:** Fast iteration, feature flags, and prototypes. Defaults are provided for quick spins.
+- **staging:** Dress rehearsal for production; validate migrations and DNS before promoting.
+- **prod:** Customer-facing; changes require approvals and runbook checklists.
+
+## Terraform Layout
+
+Environment state lives under `envs/<env>`. Each directory wires shared modules (networking, dns, monitoring, secrets) with environment-specific variables.

--- a/docs/observability-and-alerts.md
+++ b/docs/observability-and-alerts.md
@@ -1,0 +1,28 @@
+# Observability and Alerts
+
+## Key Metrics
+
+- Request latency (p50/p95/p99)
+- Error rate (4xx vs 5xx)
+- Saturation (CPU, memory, connection pools)
+- Uptime/availability per service
+
+## Minimum Alerts
+
+- Service down / healthcheck failing
+- Error rate above threshold
+- Latency above target SLOs
+- DNS resolution failures or elevated 4xx/5xx at the edge
+
+## SLO Targets (initial placeholders)
+
+- Web/API availability: 99.5%+ in dev/staging, 99.9%+ in prod
+- p95 latency: < 500ms for public endpoints
+
+## How an Incident Agent Should Use These
+
+- Read declared services from the monitoring module output
+- Compare live metrics to thresholds and trigger incident runbooks automatically
+- Post updates to communication channels and status pages
+
+> TODO(agent): Select vendor (e.g., Grafana Cloud, New Relic, Datadog) and implement alert routing.

--- a/docs/railway-guide.md
+++ b/docs/railway-guide.md
@@ -1,0 +1,24 @@
+# Railway Guide
+
+Railway is the primary PaaS for BlackRoad OS services.
+
+## Projects and Environments
+
+- Organize services into Railway projects aligned with environments (`dev`, `staging`, `prod`).
+- Each app should map to the [`app_service` module](../modules/app_service) contract once automation is ready.
+
+## Working with Railway
+
+- Login: `railway login` (TODO(agent): automate via service tokens)
+- View logs: `railway logs -s <service>`
+- Roll back: `railway up --service <service> --rollback` (placeholder)
+
+## Mapping from Terraform
+
+- Module inputs describe the desired service (domain, healthcheck, env vars).
+- Null resources echo the intended Railway CLI commands so humans/agents can execute them safely.
+
+## Future Automation
+
+- TODO(agent): Implement a Railway agent that reads Terraform state and applies creates/updates/destroys via CLI or API.
+- TODO(agent): Enforce healthcheck and rollback policies tied to runbooks.

--- a/environments/README.md
+++ b/environments/README.md
@@ -1,55 +1,11 @@
-# Environments
+# Environments (Legacy Placeholder)
 
-This directory contains environment-specific configurations for BlackRoad OS infrastructure.
+This directory previously described environment configurations. Active Terraform environment definitions now live under [`envs/`](../envs/).
 
-## Purpose
+## Current Layout
 
-Define and manage different deployment environments such as development, staging, and production.
+- `envs/dev` — Development
+- `envs/staging` — Pre-production
+- `envs/prod` — Production
 
-## What Belongs Here
-
-- Environment-specific configurations (dev, staging, production)
-- Infrastructure definitions per environment
-- Environment variables and secrets management references
-- Platform configurations (e.g., Railway, cloud providers)
-- Networking and resource allocation per environment
-
-## Structure (Future)
-
-```
-environments/
-├── dev/             # Development environment
-├── staging/         # Staging/pre-production environment
-├── production/      # Production environment
-├── shared/          # Shared resources across environments
-└── README.md        # This file
-```
-
-## Environment Tiers
-
-### Development
-- Used for active development and testing
-- May have relaxed security policies
-- Can be frequently rebuilt or reset
-
-### Staging
-- Pre-production environment
-- Mirrors production configuration
-- Used for final testing before production deployment
-
-### Production
-- Live environment serving end users
-- Strictest security and reliability requirements
-- Changes require proper approval and testing
-
-## Getting Started
-
-This directory is currently a placeholder. Environment configurations will be added as infrastructure-as-code is implemented.
-
-## Best Practices
-
-- Keep environment configurations as similar as possible
-- Use environment-specific variables rather than duplicating code
-- Document differences between environments
-- Maintain parity between staging and production
-- Never commit secrets or credentials directly
+Refer to the `envs/<env>/README.md` files for how to plan/apply infrastructure.

--- a/envs/dev/README.md
+++ b/envs/dev/README.md
@@ -1,0 +1,29 @@
+# Development Environment
+
+The development environment hosts experimental and in-progress services. Expect frequent changes and occasional instability while feature work iterates quickly.
+
+## Running Terraform
+
+```bash
+terraform init
+terraform plan -var-file=dev.tfvars
+terraform apply -var-file=dev.tfvars
+```
+
+### Required Variables and Secrets
+
+- `cloudflare_email` and `cloudflare_api_token` (or `CLOUDFLARE_API_TOKEN` when wired to env vars)
+- Any secrets declared in `var.secrets` once a secret manager is connected
+
+## Safety Checklist Before `apply`
+
+- [ ] Confirm you are in the `dev` directory
+- [ ] Use dev-specific credentials only
+- [ ] Review the Terraform plan output
+- [ ] Ensure recent changes are validated in dev services
+
+## What Runs Here
+
+- All experimental code paths and feature flags
+- Preview endpoints such as `*.dev.blackroad.systems`
+- Shared services that support rapid iteration

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -1,0 +1,64 @@
+// Environment-level Terraform configuration for the dev environment.
+// Defines providers and composes shared modules for networking, DNS, monitoring, and secrets.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">= 4.0"
+    }
+
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.1"
+    }
+
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 2.3.1"
+    }
+  }
+}
+
+provider "cloudflare" {
+  // TODO(agent): prefer CLOUDFLARE_API_TOKEN from environment once secret store is wired.
+  email     = var.cloudflare_email
+  api_token = var.cloudflare_api_token
+}
+
+provider "null" {}
+
+provider "external" {}
+
+module "networking" {
+  source = "../../modules/networking"
+  env    = var.env
+  # TODO(agent): Populate networking variables once a cloud VPC/VNet pattern is selected.
+}
+
+module "dns" {
+  source      = "../../modules/dns"
+  env         = var.env
+  zone_name   = var.zone_name
+  base_domain = var.base_domain
+  records     = var.records
+}
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+  env    = var.env
+  services = []
+  # TODO(agent): add monitored services once app inventory is defined.
+}
+
+module "secrets" {
+  source            = "../../modules/secrets"
+  env               = var.env
+  secret_store_type = "tbd"
+  secrets           = var.secrets
+  # TODO(agent): connect to a concrete secret manager.
+}
+
+# TODO(agent): Introduce module "app_service" once Railway service contract is finalized.

--- a/envs/dev/outputs.tf
+++ b/envs/dev/outputs.tf
@@ -1,0 +1,14 @@
+output "zone_id" {
+  value       = module.dns.zone_id
+  description = "Cloudflare zone ID for this environment"
+}
+
+output "dns_records" {
+  value       = module.dns.record_ids
+  description = "Map of DNS record IDs"
+}
+
+output "monitored_services" {
+  value       = module.monitoring.services
+  description = "Services declared for monitoring in this environment"
+}

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -1,0 +1,65 @@
+variable "env" {
+  description = "Environment name (dev|staging|prod)"
+  type        = string
+  default     = "dev"
+}
+
+variable "base_domain" {
+  description = "Base domain for this environment (e.g. dev.blackroad.systems)"
+  type        = string
+  default     = "dev.blackroad.systems"
+}
+
+variable "zone_name" {
+  description = "Cloudflare zone name"
+  type        = string
+  default     = "blackroad.systems"
+}
+
+variable "records" {
+  description = "DNS records specific to this environment"
+  type = list(object({
+    name    = string
+    type    = string
+    value   = string
+    proxied = bool
+    ttl     = number
+  }))
+  default = [
+    {
+      name    = "api"
+      type    = "CNAME"
+      value   = "railway.dev.blackroad.systems"
+      proxied = true
+      ttl     = 300
+    },
+    {
+      name    = "web"
+      type    = "CNAME"
+      value   = "railway.dev.blackroad.systems"
+      proxied = true
+      ttl     = 300
+    }
+  ]
+}
+
+variable "secrets" {
+  description = "Map of logical secret names to descriptions for this environment"
+  type        = map(string)
+  default = {
+    "railway_api_token"    = "API token used by agents to interact with Railway services"
+    "cloudflare_api_token" = "Token used for Cloudflare provider authentication"
+  }
+}
+
+variable "cloudflare_email" {
+  description = "Cloudflare account email"
+  type        = string
+  default     = "devnull@example.com"
+}
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token (use env vars in practice)"
+  type        = string
+  default     = "changeme"
+}

--- a/envs/prod/README.md
+++ b/envs/prod/README.md
@@ -1,0 +1,31 @@
+# Production Environment
+
+Production is the customer-facing environment. Changes here must be intentional, reviewed, and executed via infrastructure-as-code—never ad hoc console edits.
+
+## Running Terraform
+
+```bash
+terraform init
+terraform plan -var-file=prod.tfvars
+terraform apply -var-file=prod.tfvars
+```
+
+### Required Variables and Secrets
+
+- `cloudflare_email` and `cloudflare_api_token` (use environment variables where possible)
+- `base_domain`, `zone_name`, and production `records` definitions
+- Production monitoring catalogue (`services`) and required `secrets`
+
+## Safety Checklist Before `apply`
+
+- [ ] Confirm you are in the `prod` directory
+- [ ] Validate tfvars reference production-only resources
+- [ ] Plan reviewed and approved by a second operator
+- [ ] Maintenance window and rollback steps are documented
+- [ ] Backups and observability are verified
+
+## What Runs Here
+
+- Customer-facing endpoints on `*.blackroad.systems`
+- Stable builds of `blackroad-os` services promoted from staging
+- Monitoring, alerting, and secret stores tied to production accounts

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -1,0 +1,63 @@
+// Environment-level Terraform configuration for the production environment.
+// Anchors required providers and shared modules that will back customer-facing services.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">= 4.0"
+    }
+
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.1"
+    }
+
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 2.3.1"
+    }
+  }
+}
+
+provider "cloudflare" {
+  // TODO(agent): prefer CLOUDFLARE_API_TOKEN from environment once secret store is wired.
+  email     = var.cloudflare_email
+  api_token = var.cloudflare_api_token
+}
+
+provider "null" {}
+
+provider "external" {}
+
+module "networking" {
+  source = "../../modules/networking"
+  env    = var.env
+  # TODO(agent): Harden networking configuration for production traffic.
+}
+
+module "dns" {
+  source      = "../../modules/dns"
+  env         = var.env
+  zone_name   = var.zone_name
+  base_domain = var.base_domain
+  records     = var.records
+}
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+  env    = var.env
+  services = var.services
+  # TODO(agent): Plug into production monitoring/alerting vendor.
+}
+
+module "secrets" {
+  source            = "../../modules/secrets"
+  env               = var.env
+  secret_store_type = var.secret_store_type
+  secrets           = var.secrets
+}
+
+# TODO(agent): Introduce module "app_service" once Railway service contract is finalized.

--- a/envs/prod/outputs.tf
+++ b/envs/prod/outputs.tf
@@ -1,0 +1,14 @@
+output "zone_id" {
+  value       = module.dns.zone_id
+  description = "Cloudflare zone ID for this environment"
+}
+
+output "dns_records" {
+  value       = module.dns.record_ids
+  description = "Map of DNS record IDs"
+}
+
+output "monitored_services" {
+  value       = module.monitoring.services
+  description = "Services declared for monitoring in this environment"
+}

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -1,0 +1,59 @@
+variable "env" {
+  description = "Environment name (dev|staging|prod)"
+  type        = string
+}
+
+variable "base_domain" {
+  description = "Base domain for this environment (e.g. blackroad.systems)"
+  type        = string
+}
+
+variable "zone_name" {
+  description = "Cloudflare zone name"
+  type        = string
+}
+
+variable "records" {
+  description = "DNS records specific to this environment"
+  type = list(object({
+    name    = string
+    type    = string
+    value   = string
+    proxied = bool
+    ttl     = number
+  }))
+  default = []
+}
+
+variable "services" {
+  description = "List of monitored services for production"
+  type = list(object({
+    name             = string
+    type             = string
+    url              = string
+    availability_slo = string
+  }))
+  default = []
+}
+
+variable "secret_store_type" {
+  description = "Secret store backing this environment (vault|aws_ssm|gcp_sm|1password)"
+  type        = string
+  default     = "vault"
+}
+
+variable "secrets" {
+  description = "Map of logical secret names to descriptions for this environment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "cloudflare_email" {
+  description = "Cloudflare account email"
+  type        = string
+}
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token (use env vars in practice)"
+  type        = string
+}

--- a/envs/staging/README.md
+++ b/envs/staging/README.md
@@ -1,0 +1,30 @@
+# Staging Environment
+
+Staging is the pre-production proving ground. Use it to rehearse production changes, validate migrations, and mirror prod topology as closely as possible without impacting customers.
+
+## Running Terraform
+
+```bash
+terraform init
+terraform plan -var-file=staging.tfvars
+terraform apply -var-file=staging.tfvars
+```
+
+### Required Variables and Secrets
+
+- `cloudflare_email` and `cloudflare_api_token` (prefer environment variables when available)
+- `base_domain`, `zone_name`, and the `records` list for staging hostnames
+- Monitored services list (`services`) and any `secrets` entries required by downstream modules
+
+## Safety Checklist Before `apply`
+
+- [ ] Confirm you are in the `staging` directory
+- [ ] Ensure tfvars reference staging resources only
+- [ ] Review Terraform plan with a second person for riskier changes
+- [ ] Verify staging CI/CD pipelines are green before promoting builds
+
+## What Runs Here
+
+- Pre-production builds for `blackroad-os-web`, `blackroad-os-api`, `blackroad-os-core`, and console
+- Integration testing against production-like data and DNS patterns (e.g., `*.stg.blackroad.systems`)
+- Dress rehearsals for production incidents and rollbacks

--- a/envs/staging/main.tf
+++ b/envs/staging/main.tf
@@ -1,0 +1,63 @@
+// Environment-level Terraform configuration for the staging environment.
+// Declares providers and composes shared modules to mirror production safely before go-live changes.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">= 4.0"
+    }
+
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.1"
+    }
+
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 2.3.1"
+    }
+  }
+}
+
+provider "cloudflare" {
+  // TODO(agent): prefer CLOUDFLARE_API_TOKEN from environment once secret store is wired.
+  email     = var.cloudflare_email
+  api_token = var.cloudflare_api_token
+}
+
+provider "null" {}
+
+provider "external" {}
+
+module "networking" {
+  source = "../../modules/networking"
+  env    = var.env
+  # TODO(agent): Align networking with production constraints before promotion.
+}
+
+module "dns" {
+  source      = "../../modules/dns"
+  env         = var.env
+  zone_name   = var.zone_name
+  base_domain = var.base_domain
+  records     = var.records
+}
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+  env    = var.env
+  services = var.services
+  # TODO(agent): Connect staging monitoring to mirror production SLOs.
+}
+
+module "secrets" {
+  source            = "../../modules/secrets"
+  env               = var.env
+  secret_store_type = var.secret_store_type
+  secrets           = var.secrets
+}
+
+# TODO(agent): Introduce module "app_service" once Railway service contract is finalized.

--- a/envs/staging/outputs.tf
+++ b/envs/staging/outputs.tf
@@ -1,0 +1,14 @@
+output "zone_id" {
+  value       = module.dns.zone_id
+  description = "Cloudflare zone ID for this environment"
+}
+
+output "dns_records" {
+  value       = module.dns.record_ids
+  description = "Map of DNS record IDs"
+}
+
+output "monitored_services" {
+  value       = module.monitoring.services
+  description = "Services declared for monitoring in this environment"
+}

--- a/envs/staging/variables.tf
+++ b/envs/staging/variables.tf
@@ -1,0 +1,59 @@
+variable "env" {
+  description = "Environment name (dev|staging|prod)"
+  type        = string
+}
+
+variable "base_domain" {
+  description = "Base domain for this environment (e.g. stg.blackroad.systems)"
+  type        = string
+}
+
+variable "zone_name" {
+  description = "Cloudflare zone name"
+  type        = string
+}
+
+variable "records" {
+  description = "DNS records specific to this environment"
+  type = list(object({
+    name    = string
+    type    = string
+    value   = string
+    proxied = bool
+    ttl     = number
+  }))
+  default = []
+}
+
+variable "services" {
+  description = "List of monitored services for staging"
+  type = list(object({
+    name             = string
+    type             = string
+    url              = string
+    availability_slo = string
+  }))
+  default = []
+}
+
+variable "secret_store_type" {
+  description = "Secret store backing this environment (vault|aws_ssm|gcp_sm|1password)"
+  type        = string
+  default     = "vault"
+}
+
+variable "secrets" {
+  description = "Map of logical secret names to descriptions for this environment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "cloudflare_email" {
+  description = "Cloudflare account email"
+  type        = string
+}
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token (use env vars in practice)"
+  type        = string
+}

--- a/modules/app_service/README.md
+++ b/modules/app_service/README.md
@@ -1,0 +1,23 @@
+# App Service Module
+
+Declarative contract for services deployed to Railway. Captures domains, health checks, and environment variables without executing real deployments.
+
+See [USAGE.md](./USAGE.md) for examples.
+
+## Variables
+
+- `service_name` (string): Logical service name.
+- `env` (string): Environment name.
+- `domain` (string): Domain where the service is exposed.
+- `healthcheck_path` (string): Path used for liveness/health verification.
+- `env_vars` (map(string)): Environment variables to propagate.
+- `railway_project_id` (string, optional): Railway project identifier.
+
+## Outputs
+
+- `service_contract`: The declarative description captured in state for automation.
+
+## Future Work
+
+- TODO(agent): Wire Railway CLI/API automation for create/update/destroy actions.
+- TODO(agent): Attach monitoring hooks once observability tooling is chosen.

--- a/modules/app_service/USAGE.md
+++ b/modules/app_service/USAGE.md
@@ -1,0 +1,23 @@
+# App Service Module Usage
+
+This module defines the *shape* of a Railway-backed application service without performing real automation yet. State captures the intended domain, healthcheck, and environment variables so a future Railway agent can act on it.
+
+## Example
+
+```hcl
+module "api_service" {
+  source            = "../../modules/app_service"
+  service_name      = "blackroad-os-api"
+  env               = var.env
+  domain            = "api.${var.base_domain}"
+  healthcheck_path  = "/health"
+  env_vars          = { "NODE_ENV" = var.env }
+  railway_project_id = "project_xxx" # optional
+}
+```
+
+## Notes
+
+- Provisioners only `echo` the intended commands—no destructive actions occur yet.
+- TODO(agent): Replace echo commands with Railway CLI/API automation once the contract stabilizes.
+- TODO(agent): Add update hooks to react to configuration drift.

--- a/modules/app_service/main.tf
+++ b/modules/app_service/main.tf
@@ -1,0 +1,36 @@
+// Declarative contract for Railway-backed application services.
+// Uses null_resource to capture intended state; future agents can translate this into real Railway CLI/API actions.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.1"
+    }
+  }
+}
+
+resource "null_resource" "railway_service_descriptor" {
+  triggers = {
+    service_name      = var.service_name
+    env               = var.env
+    domain            = var.domain
+    healthcheck_path  = var.healthcheck_path
+    env_vars_json     = jsonencode(var.env_vars)
+    railway_project   = var.railway_project_id
+  }
+
+  provisioner "local-exec" {
+    when    = create
+    command = "echo 'TODO(agent): create/align Railway service ${var.service_name} in env ${var.env} at ${var.domain}'"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "echo 'TODO(agent): remove Railway service ${var.service_name} from env ${var.env}'"
+  }
+}
+
+# TODO(agent): Add an update path once Railway CLI/API automation is ready.

--- a/modules/app_service/outputs.tf
+++ b/modules/app_service/outputs.tf
@@ -1,0 +1,11 @@
+output "service_contract" {
+  description = "Declarative service contract captured in Terraform state"
+  value = {
+    name              = var.service_name
+    env               = var.env
+    domain            = var.domain
+    healthcheck_path  = var.healthcheck_path
+    env_vars          = var.env_vars
+    railway_project_id = var.railway_project_id
+  }
+}

--- a/modules/app_service/variables.tf
+++ b/modules/app_service/variables.tf
@@ -1,0 +1,32 @@
+variable "service_name" {
+  description = "Logical name of the application service"
+  type        = string
+}
+
+variable "env" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "domain" {
+  description = "Primary domain where the service is exposed"
+  type        = string
+}
+
+variable "healthcheck_path" {
+  description = "Path used to verify service health"
+  type        = string
+  default     = "/health"
+}
+
+variable "env_vars" {
+  description = "Environment variables to set for the service"
+  type        = map(string)
+  default     = {}
+}
+
+variable "railway_project_id" {
+  description = "Optional Railway project ID for tighter coupling"
+  type        = string
+  default     = ""
+}

--- a/modules/dns/README.md
+++ b/modules/dns/README.md
@@ -1,0 +1,32 @@
+# DNS Module
+
+Manages Cloudflare zones and DNS records for each environment. Zones can be created or referenced, and records are driven by the `records` variable so that services stay declarative.
+
+## Usage
+
+```hcl
+module "dns" {
+  source      = "../../modules/dns"
+  env         = var.env
+  zone_name   = var.zone_name
+  base_domain = var.base_domain
+  records     = var.records
+}
+```
+
+## Variables
+
+- `env` (string): Environment name.
+- `zone_name` (string): Cloudflare zone name.
+- `base_domain` (string): Base domain for fully-qualified record names.
+- `records` (list(object)): DNS records to manage (`name`, `type`, `value`, `proxied`, `ttl`).
+
+## Outputs
+
+- `zone_id`: Cloudflare zone ID.
+- `record_ids`: Map of record IDs keyed by `<name>-<type>`.
+
+## Notes
+
+- TODO(agent): If the zone is pre-existing, switch `cloudflare_zone` to a data source to avoid recreation.
+- TODO(agent): Extend record schema to support MX/TXT/SRV-specific fields when needed.

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -1,0 +1,31 @@
+// DNS module for managing Cloudflare zones and records across environments.
+// Creates or references a Cloudflare zone and provisions records defined per environment.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">= 4.0"
+    }
+  }
+}
+
+resource "cloudflare_zone" "this" {
+  zone = var.zone_name
+  plan = "free"
+
+  // TODO(agent): Switch to data source if zone is pre-existing to avoid recreation.
+}
+
+resource "cloudflare_record" "managed" {
+  for_each = { for record in var.records : "${record.name}-${record.type}" => record }
+
+  zone_id = cloudflare_zone.this.id
+  name    = "${each.value.name}.${var.base_domain}"
+  type    = each.value.type
+  content = each.value.value
+  ttl     = each.value.ttl
+  proxied = each.value.proxied
+}

--- a/modules/dns/outputs.tf
+++ b/modules/dns/outputs.tf
@@ -1,0 +1,9 @@
+output "zone_id" {
+  description = "Cloudflare zone ID"
+  value       = cloudflare_zone.this.id
+}
+
+output "record_ids" {
+  description = "Map of DNS record IDs keyed by name-type"
+  value       = { for key, record in cloudflare_record.managed : key => record.id }
+}

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -1,0 +1,26 @@
+variable "env" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "zone_name" {
+  description = "Cloudflare zone name"
+  type        = string
+}
+
+variable "base_domain" {
+  description = "Base domain for this environment (e.g. dev.blackroad.systems)"
+  type        = string
+}
+
+variable "records" {
+  description = "DNS records to manage in this zone"
+  type = list(object({
+    name    = string
+    type    = string
+    value   = string
+    proxied = bool
+    ttl     = number
+  }))
+  default = []
+}

--- a/modules/monitoring/README.md
+++ b/modules/monitoring/README.md
@@ -1,0 +1,17 @@
+# Monitoring Module
+
+Captures the list of services and target SLOs for each environment. This stub keeps observability expectations versioned while we evaluate tooling.
+
+## Variables
+
+- `env` (string): Environment name.
+- `services` (list(object)): Services to watch, with `name`, `type`, `url`, and `availability_slo` fields.
+
+## Outputs
+
+- `services`: Echoes the declared monitoring catalogue for downstream automation.
+
+## Future Work
+
+- TODO(agent): Connect to a monitoring/alerting platform.
+- TODO(agent): Emit checks and alert policies that mirror production SLOs.

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -1,0 +1,6 @@
+// Monitoring module stub to describe observability expectations per environment.
+// TODO(agent): Integrate with a monitoring/alerting vendor (e.g., Grafana Cloud, New Relic, Datadog).
+
+terraform {
+  required_version = ">= 1.5.0"
+}

--- a/modules/monitoring/outputs.tf
+++ b/modules/monitoring/outputs.tf
@@ -1,0 +1,4 @@
+output "services" {
+  description = "Services declared for monitoring"
+  value       = var.services
+}

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -1,0 +1,15 @@
+variable "env" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "services" {
+  description = "List of monitored services and their SLO targets"
+  type = list(object({
+    name             = string
+    type             = string
+    url              = string
+    availability_slo = string
+  }))
+  default = []
+}

--- a/modules/networking/README.md
+++ b/modules/networking/README.md
@@ -1,0 +1,19 @@
+# Networking Module
+
+Placeholder module that will eventually define shared networking primitives (VPC/VNet, subnets, firewalls) for every environment. Today it simply anchors the contract so downstream modules can depend on consistent interfaces.
+
+## Variables
+
+- `env` (string): Environment name.
+- `vpc_cidr` (string, optional): Placeholder for future VPC CIDR.
+- `region` (string, optional): Placeholder for provider region.
+
+## Outputs
+
+- `env`: Passthrough of the environment name.
+- `vpc_cidr`: Placeholder to keep output compatibility when networking is implemented.
+
+## Future Work
+
+- Model VPC/VNet creation when workloads require private networking beyond Railway defaults.
+- Add peering rules, security groups, and ingress controls as the architecture hardens.

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -1,0 +1,8 @@
+// Shared networking module stub. Reserved for VPC/VNet, subnets, and connectivity primitives across environments.
+// TODO(agent): Expand when self-managed compute or private networking is required beyond Railway defaults.
+
+terraform {
+  required_version = ">= 1.5.0"
+}
+
+# In the future, define VPCs, subnets, peering, firewall rules, and other primitives here.

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -1,0 +1,9 @@
+output "env" {
+  description = "Passthrough of the environment using this networking module"
+  value       = var.env
+}
+
+output "vpc_cidr" {
+  description = "Placeholder for VPC CIDR once networking is defined"
+  value       = var.vpc_cidr
+}

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -1,0 +1,16 @@
+variable "env" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the environment VPC (placeholder until a provider is selected)"
+  type        = string
+  default     = ""
+}
+
+variable "region" {
+  description = "Cloud region for networking resources"
+  type        = string
+  default     = ""
+}

--- a/modules/secrets/README.md
+++ b/modules/secrets/README.md
@@ -1,0 +1,18 @@
+# Secrets Module
+
+Defines how secrets should be organized per environment while we evaluate a concrete secret manager. Outputs are predictable paths/identifiers that an operator or agent can map to Vault, AWS SSM, GCP Secret Manager, 1Password, etc.
+
+## Variables
+
+- `env` (string): Environment name.
+- `secret_store_type` (string): Target secret store (`vault`, `aws_ssm`, `gcp_sm`, `1password`).
+- `secrets` (map(string)): Logical secrets and their descriptions.
+
+## Outputs
+
+- `secret_paths`: Map of logical secret names to expected paths (e.g., `/dev/railway_api_token`).
+
+## Future Work
+
+- TODO(agent): Bind to a real secret manager and provision secrets automatically.
+- TODO(agent): Add rotation and auditing policies once a provider is chosen.

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -1,0 +1,15 @@
+// Secrets module stub to describe how secrets should be organized per environment.
+// TODO(agent): Integrate with a concrete secret manager and enforce rotation policies.
+
+terraform {
+  required_version = ">= 1.5.0"
+}
+
+locals {
+  secret_paths = { for name, _ in var.secrets : name => "/${var.env}/${name}" }
+}
+
+output "secret_paths" {
+  description = "Expected paths or identifiers for declared secrets"
+  value       = local.secret_paths
+}

--- a/modules/secrets/outputs.tf
+++ b/modules/secrets/outputs.tf
@@ -1,0 +1,4 @@
+output "secret_paths" {
+  description = "Expected paths or identifiers for declared secrets"
+  value       = local.secret_paths
+}

--- a/modules/secrets/variables.tf
+++ b/modules/secrets/variables.tf
@@ -1,0 +1,15 @@
+variable "env" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "secret_store_type" {
+  description = "Secret store backing this environment (vault|aws_ssm|gcp_sm|1password)"
+  type        = string
+}
+
+variable "secrets" {
+  description = "Map of logical secret names to descriptions"
+  type        = map(string)
+  default     = {}
+}

--- a/runbooks/deployments/core_services.md
+++ b/runbooks/deployments/core_services.md
@@ -1,0 +1,42 @@
+# Deployment Runbook: Core Services
+
+## Scope
+
+Services: `blackroad-os-web`, `blackroad-os-api`, `blackroad-os-core`, `blackroad-os-prism-console`, and supporting agents.
+Environments: `dev`, `staging`, `prod`.
+
+## Pre-Deployment Checklist
+
+- [ ] Tests passing in relevant repos
+- [ ] CI pipeline green
+- [ ] Terraform plan for the target environment reviewed (if infra changes)
+- [ ] Change ticket / PR approved
+- [ ] Rollback steps prepared
+
+## Deployment Steps (high-level)
+
+For each service:
+
+1. Trigger deployment (Railway, CI workflow, or pipeline trigger)
+2. Tail logs for the deployment
+3. Verify `/health` and `/version` endpoints
+
+For infrastructure changes:
+
+1. `terraform init`
+2. `terraform plan -var-file=<env>.tfvars`
+3. `terraform apply -var-file=<env>.tfvars`
+
+## Post-Deployment Verification
+
+- [ ] Hit primary endpoints and health checks
+- [ ] Run smoke tests for critical user flows
+- [ ] Confirm monitoring dashboards show healthy signals and alerts are quiet
+
+## Rollback Plan
+
+- [ ] Revert to previous Railway deployment or release artifact
+- [ ] Re-run Terraform with last known-good tfstate/tfvars if infra changes were applied
+- [ ] Announce rollback and continue to monitor
+
+> TODO(agent): Fill in service-specific deployment commands and CI job links once pipelines are standardized.

--- a/runbooks/incidents/major_outage.md
+++ b/runbooks/incidents/major_outage.md
@@ -1,0 +1,46 @@
+# Incident Runbook: Major Outage
+
+## Symptoms
+
+- Complete service outage or widespread 5xx errors
+- DNS resolution failing for primary domains
+- Database unreachable or data corruption suspected
+
+## Immediate Actions
+
+- Page on-call / incident commander (or placeholder contact list)
+- Acknowledge alerts in monitoring system once available
+- Check status dashboards and platform status pages (Railway, Cloudflare)
+
+## Triaging Steps
+
+1. Validate DNS resolution for critical domains
+2. Check app health endpoints and logs
+3. Inspect database connectivity or upstream dependencies
+4. Verify recent deployments or Terraform applies
+
+## Communication
+
+- Internal update template:
+  - **What:** Brief description of impact and suspected scope
+  - **When:** Start time and current status
+  - **Actions:** Mitigations underway
+  - **Next update:** Timestamp for follow-up
+
+- External update template (if customer-facing):
+  - "We are investigating connectivity issues affecting <services>. Next update in <time>."
+
+## Rollback / Mitigation
+
+- Revert to previous Railway deployment for affected services
+- Fallback to cached responses or maintenance page if available
+- Disable problematic feature flags
+
+## Postmortem Checklist
+
+- [ ] Capture full timeline and actions taken
+- [ ] Identify root cause and contributing factors
+- [ ] List preventive follow-ups
+- [ ] Update runbooks with new learnings
+
+> TODO(agent): Automate paging hooks and status page updates once tooling is chosen.

--- a/runbooks/incidents/partial_outage.md
+++ b/runbooks/incidents/partial_outage.md
@@ -1,0 +1,46 @@
+# Incident Runbook: Partial Outage
+
+## Symptoms
+
+- One or more services degraded but core platform still responsive
+- Elevated error rates on specific endpoints
+- Regional connectivity issues or CDN-related failures
+
+## Immediate Actions
+
+- Notify on-call and relevant service owners
+- Acknowledge alerts; start incident log
+- Review recent deployments or config changes affecting impacted services
+
+## Triaging Steps
+
+1. Check Cloudflare DNS/traffic analytics for anomalies
+2. Inspect service logs for spikes in errors
+3. Validate database and upstream dependencies for the affected path
+4. Compare metrics against baselines to scope blast radius
+
+## Communication
+
+- Internal template:
+  - **Impact:** Which services/endpoints are affected
+  - **Scope:** % of traffic/users impacted
+  - **Mitigation:** Steps underway
+  - **ETA:** Next update time
+
+- External template (if needed):
+  - "We are investigating degraded performance for <service>. Users may see errors. Next update in <time>."
+
+## Mitigation Options
+
+- Roll back the last deployment for affected service(s)
+- Toggle feature flags or rate limiting
+- Increase resources or replicas if capacity-related
+
+## Postmortem Checklist
+
+- [ ] Timeline captured with owners/actions
+- [ ] Root cause identified
+- [ ] Action items created and assigned
+- [ ] Runbooks updated with specific fixes
+
+> TODO(agent): Add automated dashboards and alert routing once monitoring is in place.

--- a/runbooks/maintenance/scheduled_maintenance.md
+++ b/runbooks/maintenance/scheduled_maintenance.md
@@ -1,0 +1,37 @@
+# Scheduled Maintenance Runbook
+
+## Planning
+
+- Define scope, systems affected, and expected downtime
+- Select maintenance window with minimal user impact
+- Prepare rollback plan and backups if data is involved
+- Publish maintenance notice internally and externally
+
+## Pre-Maintenance Checklist
+
+- [ ] Confirm stakeholders and on-call contacts
+- [ ] Verify backups and recovery steps
+- [ ] Freeze non-essential deployments
+- [ ] Validate scripts/migrations in lower environments
+
+## Execution
+
+1. Place status page in maintenance mode (if available)
+2. Drain traffic if needed (e.g., disable ingress, pause jobs)
+3. Apply changes (migrations, config updates, Terraform apply)
+4. Monitor logs and metrics during the window
+
+## Verification and Bring-up
+
+- [ ] Re-enable traffic and scheduled jobs
+- [ ] Run smoke tests and health checks
+- [ ] Confirm alerts return to baseline
+- [ ] Announce completion to stakeholders
+
+## Post-Maintenance
+
+- Summarize what changed and any deviations from the plan
+- Capture follow-up tasks and owners
+- Update runbooks with lessons learned
+
+> TODO(agent): Automate maintenance notices and traffic draining once tooling is selected.


### PR DESCRIPTION
## Summary
- restructure repository around envs/modules/runbooks/docs and refresh the root README
- add Terraform environment stubs for dev/staging/prod plus reusable modules for DNS, networking, monitoring, app services, and secrets
- document environment usage, DNS patterns, Railway guidance, observability expectations, and operational runbooks

## Testing
- terraform fmt -recursive *(fails: terraform not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236fe62d588329bb8a46a5a93c6106)