### PR TITLE
Fix duplicate secret output and Cloudflare TTL defaults

### DIFF
--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -31,14 +31,14 @@ variable "records" {
       type    = "CNAME"
       value   = "railway.dev.blackroad.systems"
       proxied = true
-      ttl     = 300
+      ttl     = 1
     },
     {
       name    = "web"
       type    = "CNAME"
       value   = "railway.dev.blackroad.systems"
       proxied = true
-      ttl     = 300
+      ttl     = 1
     }
   ]
 }

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -8,8 +8,3 @@ terraform {
 locals {
   secret_paths = { for name, _ in var.secrets : name => "/${var.env}/${name}" }
 }
-
-output "secret_paths" {
-  description = "Expected paths or identifiers for declared secrets"
-  value       = local.secret_paths
-}


### PR DESCRIPTION
## Summary
- remove duplicate `secret_paths` output from the secrets module to satisfy Terraform
- set Cloudflare CNAME defaults in dev to use automatic TTL when proxied

## Testing
- not run (terraform not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692378cbb050832998f3beffa51699bf)