### PR TITLE
Add JSON service registry mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 ## Key artifacts
 
 - `infra/services.yml` — Service registry with repos, base URLs, and health endpoints.
+- `registry/services.json` — JSON mirror of the service registry for automation/CLI consumption.
 - `infra/env/*.json` — Environment maps (domain roots, Railway project IDs, per-service base URLs).
 - `infra/railway/services.md` — Railway service mappings by environment.
 - `cloudflare/DNS_BLUEPRINT.md` — DNS plan for production, staging, and development.

--- a/registry/README.md
+++ b/registry/README.md
@@ -1,0 +1,8 @@
+# Service Registry
+
+This directory exposes a machine-readable snapshot of the BlackRoad OS service map. Use `services.json` for automation, CLI tooling, or quick lookups when syncing environment variables and DNS.
+
+- Source of truth: [`infra/services.yml`](../infra/services.yml)
+- Mirror: [`services.json`](./services.json)
+
+Keep both files in sync when adding or updating services (ports, domains, health endpoints, dependencies).

--- a/registry/services.json
+++ b/registry/services.json
@@ -1,0 +1,212 @@
+{
+  "services": [
+    {
+      "id": "core",
+      "name": "blackroad-os-core",
+      "repo": "BlackRoad-OS/blackroad-os-core",
+      "kind": "library",
+      "layer": "core",
+      "description": "Domain primitives and types for identity, events, agents, and jobs.",
+      "environments": [
+        { "name": "production", "runtime": "none" },
+        { "name": "staging", "runtime": "none" },
+        { "name": "development", "runtime": "none" },
+        { "name": "local", "runtime": "none" }
+      ]
+    },
+    {
+      "id": "operator",
+      "name": "blackroad-os-operator",
+      "repo": "BlackRoad-OS/blackroad-os-operator",
+      "kind": "service",
+      "layer": "runtime",
+      "description": "Automation runtime that runs agents (including Atlas) and jobs, emits events.",
+      "environments": [
+        {
+          "name": "production",
+          "base_url": "https://operator.blackroad.systems",
+          "health_endpoint": "/internal/health",
+          "notes": "Internal-only; typically accessed via the API service."
+        },
+        {
+          "name": "staging",
+          "base_url": "https://operator.staging.blackroad.systems",
+          "health_endpoint": "/internal/health"
+        },
+        {
+          "name": "development",
+          "base_url": "https://operator.dev.blackroad.systems",
+          "health_endpoint": "/internal/health"
+        },
+        {
+          "name": "local",
+          "base_url": "http://localhost:5003",
+          "health_endpoint": "/internal/health"
+        }
+      ]
+    },
+    {
+      "id": "api",
+      "name": "blackroad-os-api",
+      "repo": "BlackRoad-OS/blackroad-os-api",
+      "kind": "service",
+      "layer": "runtime",
+      "description": "Typed HTTP surface for Prism Console and other clients.",
+      "environments": [
+        {
+          "name": "production",
+          "base_url": "https://api.blackroad.systems",
+          "health_endpoint": "/api/v1/health",
+          "system_overview_endpoint": "/api/v1/system/overview"
+        },
+        {
+          "name": "staging",
+          "base_url": "https://api.staging.blackroad.systems",
+          "health_endpoint": "/api/v1/health"
+        },
+        {
+          "name": "development",
+          "base_url": "https://api.dev.blackroad.systems",
+          "health_endpoint": "/api/v1/health"
+        },
+        {
+          "name": "local",
+          "base_url": "http://localhost:5002",
+          "health_endpoint": "/api/v1/health"
+        }
+      ]
+    },
+    {
+      "id": "prism",
+      "name": "blackroad-os-prism-console",
+      "repo": "BlackRoad-OS/blackroad-os-prism-console",
+      "kind": "web-app",
+      "layer": "interface",
+      "description": "Operator console for agents, finance, and RoadChain events.",
+      "environments": [
+        {
+          "name": "production",
+          "base_url": "https://prism.blackroad.systems",
+          "health_endpoint": "/health",
+          "depends_on": ["api"]
+        },
+        {
+          "name": "staging",
+          "base_url": "https://prism.staging.blackroad.systems",
+          "health_endpoint": "/health",
+          "depends_on": ["api"]
+        },
+        {
+          "name": "development",
+          "base_url": "https://prism.dev.blackroad.systems",
+          "health_endpoint": "/health",
+          "depends_on": ["api"]
+        },
+        {
+          "name": "local",
+          "base_url": "http://localhost:3001",
+          "health_endpoint": "/health",
+          "depends_on": ["api"]
+        }
+      ]
+    },
+    {
+      "id": "web",
+      "name": "blackroad-os-web",
+      "repo": "BlackRoad-OS/blackroad-os-web",
+      "kind": "web-app",
+      "layer": "interface",
+      "description": "Public-facing BlackRoad OS desktop shell.",
+      "environments": [
+        { "name": "production", "base_url": "https://blackroad.systems", "health_endpoint": "/health" },
+        { "name": "staging", "base_url": "https://staging.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "development", "base_url": "https://dev.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "local", "base_url": "http://localhost:3000", "health_endpoint": "/health" }
+      ]
+    },
+    {
+      "id": "docs",
+      "name": "blackroad-os-docs",
+      "repo": "BlackRoad-OS/blackroad-os-docs",
+      "kind": "web-app",
+      "layer": "docs",
+      "description": "Canonical documentation site.",
+      "environments": [
+        { "name": "production", "base_url": "https://docs.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "staging", "base_url": "https://docs.staging.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "development", "base_url": "https://docs.dev.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "local", "base_url": "http://localhost:3002", "health_endpoint": "/health" }
+      ]
+    },
+    {
+      "id": "home",
+      "name": "blackroad-os-home",
+      "repo": "BlackRoad-OS/blackroad-os-home",
+      "kind": "web-app",
+      "layer": "interface",
+      "description": "Home shell experience for connecting BlackRoad OS properties.",
+      "environments": [
+        { "name": "production", "base_url": "https://home.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "staging", "base_url": "https://home.staging.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "development", "base_url": "https://home.dev.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "local", "base_url": "http://localhost:3003", "health_endpoint": "/health" }
+      ]
+    },
+    {
+      "id": "brand",
+      "name": "blackroad-os-brand",
+      "repo": "BlackRoad-OS/blackroad-os-brand",
+      "kind": "web-app",
+      "layer": "interface",
+      "description": "Brand system and visual language reference for BlackRoad OS.",
+      "environments": [
+        { "name": "production", "base_url": "https://brand.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "staging", "base_url": "https://brand.staging.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "development", "base_url": "https://brand.dev.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "local", "base_url": "http://localhost:3004", "health_endpoint": "/health" }
+      ]
+    },
+    {
+      "id": "ideas",
+      "name": "blackroad-os-ideas",
+      "repo": "BlackRoad-OS/blackroad-os-ideas",
+      "kind": "web-app",
+      "layer": "interface",
+      "description": "Idea backlog and experiments surface.",
+      "environments": [
+        { "name": "production", "base_url": "https://ideas.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "staging", "base_url": "https://ideas.staging.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "development", "base_url": "https://ideas.dev.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "local", "base_url": "http://localhost:3005", "health_endpoint": "/health" }
+      ]
+    },
+    {
+      "id": "demo",
+      "name": "blackroad-os-demo",
+      "repo": "BlackRoad-OS/blackroad-os-demo",
+      "kind": "web-app",
+      "layer": "interface",
+      "description": "Demo and world showcase for BlackRoad OS.",
+      "environments": [
+        { "name": "production", "base_url": "https://demo.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "staging", "base_url": "https://demo.staging.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "development", "base_url": "https://demo.dev.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "local", "base_url": "http://localhost:3006", "health_endpoint": "/health" }
+      ]
+    },
+    {
+      "id": "research",
+      "name": "blackroad-os-research",
+      "repo": "BlackRoad-OS/blackroad-os-research",
+      "kind": "web-app",
+      "layer": "research",
+      "description": "Research notebooks and experimental explorations.",
+      "environments": [
+        { "name": "production", "base_url": "https://research.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "staging", "base_url": "https://research.staging.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "development", "base_url": "https://research.dev.blackroad.systems", "health_endpoint": "/health" },
+        { "name": "local", "base_url": "http://localhost:3007", "health_endpoint": "/health" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a machine-readable services.json that mirrors the existing service registry
- document the registry directory for automation consumers
- note the JSON mirror in the repository README

## Testing
- not run (documentation/data-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239dc5fc388329a2b482a287efd76a)