### PR TITLE
Add deploy orchestrator utilities and dependencies

### DIFF
--- a/.pssha/audit.ts
+++ b/.pssha/audit.ts
@@ -1,0 +1,57 @@
+import fs from "fs";
+import path from "path";
+
+interface AuditEntry {
+  hash: string;
+  timestamp: string;
+  agent: string;
+  service: string;
+  reason: string;
+}
+
+interface WriteAuditOptions extends AuditEntry {
+  file: string;
+}
+
+function ensureDir(filePath: string) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function readAuditLog(filePath: string): AuditEntry[] {
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed)) {
+      return parsed as AuditEntry[];
+    }
+  } catch (error) {
+    console.warn(`Could not read audit log ${filePath}:`, error);
+  }
+
+  return [];
+}
+
+export function writeAuditHash(options: WriteAuditOptions) {
+  const logPath = path.resolve(options.file);
+  ensureDir(logPath);
+
+  const entries = readAuditLog(logPath);
+  entries.push({
+    hash: options.hash,
+    timestamp: options.timestamp,
+    agent: options.agent,
+    service: options.service,
+    reason: options.reason,
+  });
+
+  fs.writeFileSync(logPath, `${JSON.stringify(entries, null, 2)}\n`);
+}
+
+export type { AuditEntry, WriteAuditOptions };

--- a/dns/cloudflare.ts
+++ b/dns/cloudflare.ts
@@ -1,0 +1,144 @@
+import path from "path";
+import fs from "fs";
+
+export interface UpdateDNSParams {
+  zone: string;
+  name: string;
+  type: "A" | "AAAA" | "CNAME" | "TXT";
+  value: string;
+  proxied?: boolean;
+  ttl?: number;
+}
+
+interface CloudflareResponse<T> {
+  success: boolean;
+  errors: { code: number; message: string }[];
+  result: T;
+}
+
+const API_BASE = "https://api.cloudflare.com/client/v4";
+
+function loadToken(): string {
+  const token = process.env.CLOUDFLARE_API_TOKEN;
+
+  if (token && token.trim().length > 0) {
+    return token.trim();
+  }
+
+  const tokenFile = path.resolve("secrets", "cf_api_token.env");
+  if (fs.existsSync(tokenFile)) {
+    const raw = fs.readFileSync(tokenFile, "utf-8");
+    const envToken = raw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line.startsWith("CLOUDFLARE_API_TOKEN="));
+
+    if (envToken) {
+      const value = envToken.split("=").slice(1).join("=").trim();
+      if (value) {
+        return value;
+      }
+    }
+  }
+
+  throw new Error(
+    "CLOUDFLARE_API_TOKEN not provided. Set env or add secrets/cf_api_token.env"
+  );
+}
+
+async function fetchJson<T>(url: string, init: RequestInit): Promise<T> {
+  const response = await fetch(url, init);
+  const data = (await response.json()) as CloudflareResponse<T>;
+
+  if (!data.success) {
+    const message = data.errors.map((e) => `${e.code}: ${e.message}`).join(", ");
+    throw new Error(`Cloudflare API error: ${message || response.statusText}`);
+  }
+
+  return data.result;
+}
+
+async function getZoneId(token: string, zone: string): Promise<string> {
+  const url = `${API_BASE}/zones?name=${encodeURIComponent(zone)}`;
+  const result = await fetchJson<{ id: string }[]>(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  const zoneInfo = result[0];
+  if (!zoneInfo) {
+    throw new Error(`Zone not found for ${zone}`);
+  }
+
+  return zoneInfo.id;
+}
+
+async function findExistingRecord(
+  token: string,
+  zoneId: string,
+  name: string,
+  type: string
+): Promise<{ id: string } | undefined> {
+  const url = `${API_BASE}/zones/${zoneId}/dns_records?type=${encodeURIComponent(
+    type
+  )}&name=${encodeURIComponent(name)}`;
+
+  const result = await fetchJson<{ id: string }[]>(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  return result[0];
+}
+
+async function upsertRecord(
+  token: string,
+  zoneId: string,
+  params: UpdateDNSParams
+) {
+  const payload = {
+    type: params.type,
+    name: `${params.name}.${params.zone}`.replace(/\.+$/, ""),
+    content: params.value,
+    ttl: params.ttl ?? 120,
+    proxied: params.proxied ?? true,
+  };
+
+  const existing = await findExistingRecord(token, zoneId, payload.name, payload.type);
+
+  if (existing) {
+    await fetchJson(`${API_BASE}/zones/${zoneId}/dns_records/${existing.id}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+    return;
+  }
+
+  await fetchJson(`${API_BASE}/zones/${zoneId}/dns_records`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateDNS(params: UpdateDNSParams) {
+  const token = loadToken();
+  const zoneId = await getZoneId(token, params.zone);
+  await upsertRecord(token, zoneId, params);
+  return {
+    zoneId,
+    record: `${params.name}.${params.zone}`,
+    value: params.value,
+  };
+}

--- a/ops/deploy.ts
+++ b/ops/deploy.ts
@@ -1,296 +1,115 @@
-import { spawn } from 'child_process';
-import { mkdir, readFile, stat, writeFile } from 'fs/promises';
-import path from 'path';
+// File: ops/deploy.ts
 
-interface DeployGitOptions {
-  branch: string;
-  url: string;
-}
-
-interface DeployDnsOptions {
-  provider: 'cloudflare';
-  recordType: 'A' | 'CNAME';
-  challenge?: string;
-  target: string;
-}
+import { execSync, spawn } from "child_process";
+import fs from "fs";
+import path from "path";
+import dotenv from "dotenv";
+import { updateDNS } from "../dns/cloudflare";
+import { writeAuditHash } from "../.pssha/audit";
+import { logDeployment } from "../registry/register";
 
 interface DeployOptions {
   repo: string;
-  domain: string;
-  runtime: 'node' | 'pm2' | 'docker';
+  branch?: string;
   port: number;
-  env: 'production' | 'staging' | 'development' | 'local';
-  memory: string;
-  agent: string;
-  git: DeployGitOptions;
+  domain: string;
   entry: string;
-  envVars: string[];
-  dns: DeployDnsOptions;
-}
-
-interface RegistryEntry {
-  service: string;
-  domain: string;
+  envFile: string;
   agent: string;
-  env: string;
-  repo: string;
-  branch: string;
-  runtime: string;
-  port: number;
-  target: string;
-  deployedAt: string;
-}
-
-interface DeploymentEvent {
-  ok: boolean;
-  service: string;
-  url: string;
-  agent: string;
-  timestamp: string;
-}
-
-const DEPLOYMENTS_ROOT = path.join(process.cwd(), 'ops', '.deployments');
-const REGISTRY_FILE = path.join(process.cwd(), 'registry', 'services.json');
-const CF_TOKEN_FILE = path.join(process.cwd(), 'secrets', 'cf_api_token.env');
-
-function logStep(step: string) {
-  console.info(`\n▶ ${step}`);
-}
-
-async function runCommand(command: string, args: string[], cwd?: string, env?: NodeJS.ProcessEnv) {
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd,
-      stdio: 'inherit',
-      env: env ?? process.env,
-    });
-
-    child.on('error', reject);
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
-      }
-    });
-  });
-}
-
-async function ensureDir(dir: string) {
-  try {
-    const stats = await stat(dir);
-    if (!stats.isDirectory()) {
-      throw new Error(`${dir} exists but is not a directory`);
-    }
-  } catch (error: unknown) {
-    await mkdir(dir, { recursive: true });
-  }
-}
-
-async function cloneRepo(repoDir: string, git: DeployGitOptions) {
-  const repoExists = await stat(repoDir).then(() => true).catch(() => false);
-
-  if (!repoExists) {
-    await ensureDir(path.dirname(repoDir));
-    logStep(`Cloning ${git.url} (branch: ${git.branch})`);
-    await runCommand('git', ['clone', '--branch', git.branch, git.url, repoDir]);
-    return;
-  }
-
-  logStep('Refreshing existing clone');
-  await runCommand('git', ['fetch'], repoDir);
-  await runCommand('git', ['checkout', git.branch], repoDir);
-  await runCommand('git', ['reset', '--hard', `origin/${git.branch}`], repoDir);
-}
-
-async function installAndBuild(repoDir: string) {
-  logStep('Installing dependencies');
-  await runCommand('npm', ['install'], repoDir);
-
-  logStep('Building service');
-  await runCommand('npm', ['run', 'build'], repoDir);
-}
-
-async function startRuntime(runtime: DeployOptions['runtime'], entry: string, repoDir: string, envVars: string[]) {
-  const [command, ...args] = entry.split(' ');
-  const env = {
-    ...process.env,
-    ...Object.fromEntries(envVars.map((item) => item.split('='))),
-  } as NodeJS.ProcessEnv;
-
-  logStep(`Launching runtime (${runtime})`);
-
-  if (runtime === 'node') {
-    await runCommand(command, args, repoDir, env);
-    return;
-  }
-
-  if (runtime === 'pm2') {
-    await runCommand('pm2', ['start', command, '--name', path.basename(repoDir), '--', ...args], repoDir, env);
-    return;
-  }
-
-  if (runtime === 'docker') {
-    await runCommand('docker', ['build', '-t', path.basename(repoDir), '.'], repoDir, env);
-    await runCommand(
-      'docker',
-      ['run', '--rm', '-d', '-p', `${env.PORT || '3000'}:${env.PORT || '3000'}`, path.basename(repoDir)],
-      repoDir,
-      env,
-    );
-  }
-}
-
-async function loadCloudflareToken(): Promise<string | undefined> {
-  const tokenExists = await stat(CF_TOKEN_FILE).then(() => true).catch(() => false);
-  if (!tokenExists) {
-    console.warn('Cloudflare token file not found; DNS step will be skipped');
-    return undefined;
-  }
-
-  const contents = await readFile(CF_TOKEN_FILE, 'utf-8');
-  const line = contents.split('\n').find((l) => l.startsWith('CLOUDFLARE_API_TOKEN='));
-  return line?.split('=')[1]?.trim();
-}
-
-async function addDnsRecord(dns: DeployDnsOptions, domain: string) {
-  if (dns.provider !== 'cloudflare') {
-    console.warn(`DNS provider ${dns.provider} not supported`);
-    return;
-  }
-
-  const token = await loadCloudflareToken();
-  if (!token) {
-    return;
-  }
-
-  logStep(`Adding DNS record for ${domain} -> ${dns.target}`);
-  const payload = {
-    type: dns.recordType,
-    name: domain,
-    content: dns.target,
-    ttl: 120,
-    proxied: true,
+  runtime: "node" | "docker";
+  memory: {
+    hash: string;
+    journalFile: string;
+    reason: string;
   };
+  dns: {
+    provider: "cloudflare";
+    recordName: string;
+    zone: string;
+    targetIP: string;
+  };
+}
 
-  const response = await fetch('https://api.cloudflare.com/client/v4/zones', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
+export async function deploy(config: DeployOptions) {
+  const {
+    repo,
+    branch = "main",
+    port,
+    domain,
+    entry,
+    envFile,
+    runtime,
+    agent,
+    memory,
+    dns,
+  } = config;
+
+  const repoDir = path.resolve("services", repo);
+  const cloneUrl = `https://github.com/BlackRoad-OS/${repo}.git`;
+
+  console.log(`🚀 Deploying ${repo} to ${domain} on port ${port}…`);
+
+  // 1. Clone repo
+  if (!fs.existsSync(repoDir)) {
+    execSync(`git clone --branch ${branch} ${cloneUrl} ${repoDir}`, {
+      stdio: "inherit",
+    });
+  } else {
+    execSync(`git pull`, { cwd: repoDir, stdio: "inherit" });
+  }
+
+  // 2. Inject .env
+  const envVars = dotenv.parse(fs.readFileSync(envFile));
+  const envPath = path.join(repoDir, ".env");
+  fs.writeFileSync(
+    envPath,
+    Object.entries(envVars)
+      .map(([key, val]) => `${key}=${val}`)
+      .join("\n")
+  );
+  console.log(`✅ Injected env from ${envFile}`);
+
+  // 3. Build & start service
+  if (runtime === "node") {
+    execSync(`npm install`, { cwd: repoDir, stdio: "inherit" });
+    execSync(`npm run build || true`, { cwd: repoDir, stdio: "inherit" });
+
+    execSync(`pm2 delete ${repo} || true`, { stdio: "ignore" });
+    execSync(`pm2 start ${entry} --name "${repo}" --cwd "${repoDir}" --env production -- --port ${port}`, {
+      stdio: "inherit",
+    });
+  }
+
+  console.log(`✅ Service started on port ${port}`);
+
+  // 4. Update DNS
+  await updateDNS({
+    zone: dns.zone,
+    name: dns.recordName,
+    type: "A",
+    value: dns.targetIP,
   });
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(`Failed to create DNS record: ${message}`);
-  }
-}
+  console.log(`✅ DNS updated: ${domain} → ${dns.targetIP}`);
 
-async function loadRegistry(): Promise<RegistryEntry[]> {
-  const registryExists = await stat(REGISTRY_FILE).then(() => true).catch(() => false);
-  if (!registryExists) {
-    await ensureDir(path.dirname(REGISTRY_FILE));
-    return [];
-  }
-
-  const contents = await readFile(REGISTRY_FILE, 'utf-8');
-  try {
-    return JSON.parse(contents) as RegistryEntry[];
-  } catch (error: unknown) {
-    console.warn('Registry file unreadable; resetting to empty array');
-    return [];
-  }
-}
-
-async function writeRegistry(entry: RegistryEntry) {
-  await ensureDir(path.dirname(REGISTRY_FILE));
-  const registry = await loadRegistry();
-  const filtered = registry.filter((item) => item.service !== entry.service || item.env !== entry.env);
-  filtered.push(entry);
-  await writeFile(REGISTRY_FILE, `${JSON.stringify(filtered, null, 2)}\n`);
-}
-
-async function emitDeploymentEvent(options: DeployOptions): Promise<DeploymentEvent> {
-  return {
-    ok: true,
-    service: options.repo,
-    url: `https://${options.domain}`,
-    agent: options.agent,
+  // 5. Write audit hash + journal
+  writeAuditHash({
+    hash: memory.hash,
     timestamp: new Date().toISOString(),
-  };
-}
-
-export async function deploy(options: DeployOptions) {
-  const repoDir = path.join(DEPLOYMENTS_ROOT, options.repo);
-
-  await ensureDir(DEPLOYMENTS_ROOT);
-  await cloneRepo(repoDir, options.git);
-  await installAndBuild(repoDir);
-  await startRuntime(options.runtime, options.entry, repoDir, options.envVars);
-  await addDnsRecord(options.dns, options.domain);
-
-  await writeRegistry({
-    service: options.repo,
-    domain: options.domain,
-    agent: options.agent,
-    env: options.env,
-    repo: options.git.url,
-    branch: options.git.branch,
-    runtime: options.runtime,
-    port: options.port,
-    target: options.dns.target,
-    deployedAt: new Date().toISOString(),
+    agent,
+    service: repo,
+    reason: memory.reason,
+    file: memory.journalFile,
   });
 
-  const event = await emitDeploymentEvent(options);
-  logStep('Deployment complete');
-  console.info(JSON.stringify(event, null, 2));
-  return event;
-}
-
-const presets: Record<string, DeployOptions> = {
-  web: {
-    repo: 'blackroad-os-web',
-    domain: 'web.blackroad.systems',
-    runtime: 'node',
-    port: 3100,
-    env: 'production',
-    memory: 'ps-sha∞',
-    agent: 'cadillac',
-    git: {
-      branch: 'main',
-      url: 'https://github.com/BlackRoad-OS/blackroad-os-web.git',
-    },
-    entry: 'npm run start',
-    envVars: [
-      'NODE_ENV=production',
-      'PORT=3100',
-      'FRONTEND_URL=https://web.blackroad.systems',
-      'LUCIDIA_HOST=https://core.blackroad.systems',
-      'ROADCHAIN_API=https://roadchain.blackroad.systems',
-    ],
-    dns: {
-      provider: 'cloudflare',
-      recordType: 'A',
-      challenge: '_web-verify.blackroad.systems',
-      target: '1.2.3.4',
-    },
-  },
-};
-
-if (require.main === module) {
-  const target = process.argv[2];
-  const preset = presets[target];
-
-  if (!preset) {
-    console.error(`Unknown target "${target}". Available presets: ${Object.keys(presets).join(', ') || 'none'}`);
-    process.exit(1);
-  }
-
-  deploy(preset).catch((error) => {
-    console.error('Deployment failed:', error);
-    process.exit(1);
+  // 6. Register in system registry
+  logDeployment({
+    service: repo,
+    domain,
+    port,
+    agent,
+    hash: memory.hash,
   });
+
+  console.log(`✅ Deployment of ${repo} completed successfully.`);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,249 @@
+{
+  "name": "blackroad-os-infra",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "blackroad-os-infra",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "devDependencies": {
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "scripts": {
     "deploy": "ts-node ops/deploy.ts"
   },
+  "dependencies": {
+    "dotenv": "^16.4.5"
+  },
   "devDependencies": {
     "ts-node": "^10.9.2",
     "typescript": "^5.4.0"

--- a/registry/register.ts
+++ b/registry/register.ts
@@ -1,0 +1,62 @@
+import fs from "fs";
+import path from "path";
+
+interface DeploymentRecord {
+  service: string;
+  domain: string;
+  port: number;
+  agent: string;
+  hash: string;
+  deployedAt: string;
+}
+
+interface LogDeploymentOptions {
+  service: string;
+  domain: string;
+  port: number;
+  agent: string;
+  hash: string;
+}
+
+function ensureDir(filePath: string) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function readRegistry(filePath: string): DeploymentRecord[] {
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed as DeploymentRecord[];
+    }
+    if (parsed && Array.isArray((parsed as { deployments?: DeploymentRecord[] }).deployments)) {
+      return (parsed as { deployments: DeploymentRecord[] }).deployments;
+    }
+  } catch (error) {
+    console.warn(`Could not read registry file ${filePath}:`, error);
+  }
+
+  return [];
+}
+
+export function logDeployment(options: LogDeploymentOptions) {
+  const registryFile = path.resolve("registry", "deployments.json");
+  ensureDir(registryFile);
+
+  const deployments = readRegistry(registryFile);
+  deployments.push({
+    ...options,
+    deployedAt: new Date().toISOString(),
+  });
+
+  fs.writeFileSync(registryFile, `${JSON.stringify(deployments, null, 2)}\n`);
+}
+
+export type { DeploymentRecord, LogDeploymentOptions };


### PR DESCRIPTION
## Summary
- replace ops/deploy.ts with the new agent-aware deployment orchestrator that injects env files, starts services, updates DNS, and records audit/registry entries
- add Cloudflare DNS helper, PS-SHA∞ audit logger, and registry deployment logger utilities
- include dotenv dependency and generate lockfile for the new tooling

## Testing
- npm install

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923a2131f1c8329ad8c83e0823fc3b6)