### PR TITLE
Add BlackRoad master infrastructure blueprint

### DIFF
--- a/docs/BLACKROAD_INFRA.md
+++ b/docs/BLACKROAD_INFRA.md
@@ -317,7 +317,7 @@ Projects:
 
 - `blackroad-web`
   - URL: `https://blackroad-web.vercel.app/`
-  - Repo: `github.com/blackboxprogramming/blackroad-prism-console` (linked integration)
+  - Repo: `github.com/blackboxprogramming/blackroad-prism-console` (linked integration; note: this project is deployed from the prism-console repo due to monorepo structure / legacy reasons. If you expect a dedicated repo, see maintainers for details.)
 - `portals`
   - URL: `https://blackroad.io/` (Vercel project connected to apex domain)
   - Repo: `blackboxprogramming/blackroad-prism-console`


### PR DESCRIPTION
## Summary
- add the BLACKROAD_INFRA.md blueprint as the canonical infrastructure source of truth

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246ffbac7c8329aebec436aa4a0621)