### PR TITLE
Add blackroad.systems services to status page

### DIFF
--- a/status/index.html
+++ b/status/index.html
@@ -265,6 +265,21 @@
             { name: 'Demo', url: 'demo.blackroad.io', category: 'Web' },
             { name: 'Docs', url: 'docs.blackroad.io', category: 'Web' },
             { name: 'Brand', url: 'brand.blackroad.io', category: 'Web' },
+            { name: 'API Gateway (.systems)', url: 'api.blackroad.systems', category: 'Systems' },
+            { name: 'Core (.systems)', url: 'core.blackroad.systems', category: 'Systems' },
+            { name: 'Infra (.systems)', url: 'infra.blackroad.systems', category: 'Systems' },
+            { name: 'Console (.systems)', url: 'console.blackroad.systems', category: 'Systems' },
+            { name: 'Docs (.systems)', url: 'docs.blackroad.systems', category: 'Systems' },
+            { name: 'Prism (.systems)', url: 'prism.blackroad.systems', category: 'Systems' },
+            { name: 'Beacon (.systems)', url: 'beacon.blackroad.systems', category: 'Systems' },
+            { name: 'Research (.systems)', url: 'research.blackroad.systems', category: 'Systems' },
+            { name: 'Demo (.systems)', url: 'demo.blackroad.systems', category: 'Systems' },
+            { name: 'Archive (.systems)', url: 'archive.blackroad.systems', category: 'Systems' },
+            { name: 'Agents (.systems)', url: 'agents.blackroad.systems', category: 'Systems' },
+            { name: 'Finance Pack', url: 'finance.blackroad.systems', category: 'Packs' },
+            { name: 'Legal Pack', url: 'legal.blackroad.systems', category: 'Packs' },
+            { name: 'Lab Pack', url: 'lab.blackroad.systems', category: 'Packs' },
+            { name: 'DevOps Pack', url: 'devops.blackroad.systems', category: 'Packs' },
         ];
 
         async function checkService(service) {


### PR DESCRIPTION
## Summary
- add blackroad.systems services and packs to the public status page service list for monitoring

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fa6050e6c832991168596b81d8d93)