### PR TITLE
Add infrastructure blueprint for blackroad-os-core service

### DIFF
--- a/railway/railway.blackroad-os-core.toml
+++ b/railway/railway.blackroad-os-core.toml
@@ -1,0 +1,57 @@
+# Railway Service Configuration: blackroad-os-core
+
+[service]
+name = "blackroad-os-core"
+description = "Core runtime service providing primary OS APIs and workspace state"
+
+[build]
+builder = "NIXPACKS"
+buildCommand = "pnpm install --frozen-lockfile && pnpm build"
+
+[deploy]
+startCommand = "pnpm start"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3
+
+[healthcheck]
+path = "/health"
+interval = 30
+timeout = 5
+
+[network]
+# Port is set via $PORT environment variable by Railway
+# Default: 9000
+
+# Environment-specific configuration
+# Actual values are set in Railway dashboard, not here
+
+[env]
+# Required - set in Railway dashboard
+# BR_OS_ENV = "staging" or "prod"
+# BR_OS_CORE_VERSION = "0.1.0"
+# BR_OS_CORE_COMMIT = "$RAILWAY_GIT_COMMIT_SHA"
+# NODE_ENV = "production"
+# PORT = "$PORT"
+# DATABASE_URL = "[Postgres connection string]"
+
+# Optional - set in Railway dashboard if needed
+# REDIS_URL = "[Redis URL for cache/session]"
+# SESSION_SECRET = "[Secret for sessions/auth]"
+# ALLOWED_ORIGINS = "https://app.blackroad.io,https://console.blackroad.io"
+# LOG_LEVEL = "info"
+# ENABLE_METRICS = "true"
+
+[resources]
+# Staging: 1 vCPU, 1GB
+# Production: 1-2 vCPU, 2-4GB
+# Set in Railway dashboard
+
+[scaling]
+# Staging: 1 instance
+# Production: 2+ instances for high availability
+# Configure in Railway dashboard
+
+[notes]
+# Primary service for auth, workspace orchestration, and stateful operations
+# Ensure migrations run before deploy
+# Repository: https://github.com/BlackRoad-OS/blackroad-os-core

--- a/scripts/validate-infra.ts
+++ b/scripts/validate-infra.ts
@@ -29,7 +29,7 @@ interface EnvironmentsConfig {
 
 const REPO_ROOT = path.join(__dirname, '..');
 const REQUIRED_ENVS = ['local', 'staging', 'prod'];
-const CORE_SERVICES = ['api', 'operator', 'web', 'prism-console'];
+const CORE_SERVICES = ['core', 'api', 'operator', 'web', 'prism-console'];
 
 let hasErrors = false;
 

--- a/services/core/infra.yml
+++ b/services/core/infra.yml
@@ -1,0 +1,90 @@
+# Infrastructure Blueprint: blackroad-os-core
+
+Core runtime service providing the primary OS APIs, identity, and workspace logic.
+
+## Service Overview
+- **Service Name**: blackroad-os-core
+- **Type**: Core runtime API/UI
+- **Language**: Node.js/TypeScript
+- **Repository**: https://github.com/BlackRoad-OS/blackroad-os-core
+
+## Deployment Configuration
+
+### Local Environment
+```yaml
+platform: local
+entrypoint: "pnpm dev"
+port: 9000
+dependencies:
+  - postgres (required)
+  - redis (optional)
+```
+
+### Staging Environment
+```yaml
+platform: railway
+railway_project: "blackroad-os-core-staging"
+port: 9000
+domain: "core.staging.blackroad.io"
+healthcheck: "/health"
+auto_deploy: true
+branch: "main"
+```
+
+### Production Environment
+```yaml
+platform: railway
+railway_project: "blackroad-os-core-prod"
+port: 9000
+domain: "core.blackroad.systems"
+healthcheck: "/health"
+auto_deploy: false  # manual approval
+branch: "main"
+```
+
+## Environment Variables
+
+### Required (All Environments)
+- `BR_OS_ENV` - Environment name: local/staging/prod
+- `BR_OS_CORE_VERSION` - Deployed version string
+- `BR_OS_CORE_COMMIT` - Git commit SHA
+- `PORT` - HTTP port (default: 9000)
+- `DATABASE_URL` - Primary Postgres connection string
+
+### Optional
+- `REDIS_URL` - Redis connection string for caching/sessions
+- `SESSION_SECRET` - Session/auth secret (stored in provider secrets manager)
+- `LOG_LEVEL` - Logging verbosity: debug/info/warn/error
+- `ENABLE_METRICS` - Enable metrics export (default: true)
+- `ALLOWED_ORIGINS` - Comma-separated CORS origins
+
+## Resource Requirements
+
+### Local
+- CPU: Best effort
+- Memory: 512MB minimum
+- Disk: Minimal
+
+### Staging
+- CPU: 1 vCPU
+- Memory: 1GB
+- Disk: 2GB
+- Instances: 1
+
+### Production
+- CPU: 1-2 vCPU
+- Memory: 2-4GB
+- Disk: 4GB+
+- Instances: 2+ (HA)
+
+## Health Checks
+- Endpoint: `GET /health`
+- Expected Response: 200 OK with JSON body
+- Interval: 30s
+- Timeout: 5s
+- Unhealthy Threshold: 3
+
+## Notes
+- Central orchestrator for auth, state, and workspace data.
+- Should enforce strict request logging and correlation IDs.
+- Downstream services (api/operator/packs) depend on this service being healthy.


### PR DESCRIPTION
## Summary
- add infrastructure blueprint for the core runtime service with environment details
- include Railway configuration for blackroad-os-core deployments
- update validation script to cover the core service assets

## Testing
- npm run validate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5fcfa1648329b0474452163d7ef1)